### PR TITLE
fix: corrected negative time_taken from schema history

### DIFF
--- a/ingest_classes/base_class.py
+++ b/ingest_classes/base_class.py
@@ -318,7 +318,7 @@ class BaseClass(ABC):
             None.
         """
 
-        time_taken = int((start_time - end_time).total_seconds())
+        time_taken = int((end_time - start_time).total_seconds())
         start_time_str = start_time.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
         end_time_str = end_time.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 


### PR DESCRIPTION
The `time_taken` calculation in write_to_history had start minus end, this needed reversing.